### PR TITLE
flags for poor people having two graphic cards

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -1,3 +1,10 @@
+//have been shocked, wglGetProc("glBufferData") failed, 
+//then remembered that integrated graphic has incomplete gl-standards
+//for notebooks, choose graphicscard instead of embedded intel-graphics.
+//nv and amd look for theese exported flags
+_declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+_declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+
 
 #define m_gl_funcs \
 X(PFNGLBUFFERDATAPROC, glBufferData) \


### PR DESCRIPTION
dllexports to mark preferred graphics-device, amd and nvidia drivers look for these.