### PR TITLE
fix skip level when chatting + some warnings

### DIFF
--- a/linux_build.sh
+++ b/linux_build.sh
@@ -5,7 +5,7 @@ if [ $cc = "g++" ] ; then
 else
 	diag="-fno-caret-diagnostics"
 fi
-warn="-Werror -Wall -Wno-char-subscripts -Wno-unused-function -Wno-switch"
+warn="-Werror -Wall -Wno-char-subscripts -Wno-unused-function -Wno-switch -Wno-class-memaccess -Wno-sign-compare"
 serverdef="-Dm_server -Dm_app"
 clientdef="-Dm_client -Dm_app"
 opt_debug="-std=c++17 -Isrc/ -g -Dm_debug"
@@ -42,7 +42,7 @@ else
 	compile_server=1
 fi
 
-if [ $debug = 0 ] ; then
+if [ $debug = 1 ] ; then
 	opt=$opt_debug
 else
 	opt=$opt_release

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,24 +1,25 @@
 #define m_client 1
 static constexpr int ENET_PACKET_FLAG_RELIABLE = 1;
 
+#include "external/glcorearb.h"
+
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 // @Note(tkap, 24/06/2023): We don't want this Madeg
 #include <windows.h>
 
 #include <GL/gl.h>
-#include "external/glcorearb.h"
 #include "external/wglext.h"
 #include <stdlib.h>
 #define m_dll_export __declspec(dllexport)
 #else
 #include<X11/X.h>
 #include<X11/Xlib.h>
-#include<GL/gl.h>
 #include<GL/glx.h>
-#include<GL/glext.h>
-#include <x86intrin.h>
 #include <string.h>
+#ifdef __GNUC__
+#define __rdtsc __builtin_ia32_rdtsc
+#endif
 #include <stdarg.h>
 #include <unistd.h>
 #define m_dll_export
@@ -79,7 +80,7 @@ m_update_game(update_game)
 	static_assert(c_game_memory >= sizeof(s_game));
 	static_assert((c_max_entities % c_num_threads) == 0);
 	game = (s_game*)game_memory;
-	frame_arena = &platform_data.frame_arena;
+	frame_arena = platform_data.frame_arena;
 	g_platform_funcs = platform_funcs;
 	g_platform_data = platform_data;
 	g_network = game_network;
@@ -211,15 +212,15 @@ func void update(s_config config)
 
 			// vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv		cheats, for testing start		vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 			#ifdef m_debug
-			if(is_key_pressed(c_key_add))
+			if(is_key_pressed(c_key_add) && !game->chatting)
 			{
 				send_simple_packet(e_packet_cheat_next_level, ENET_PACKET_FLAG_RELIABLE);
 			}
-			if(is_key_pressed(c_key_subtract))
+			if(is_key_pressed(c_key_subtract) && !game->chatting)
 			{
 				send_simple_packet(e_packet_cheat_previous_level, ENET_PACKET_FLAG_RELIABLE);
 			}
-			if(is_key_pressed(c_key_f1))
+			if(is_key_pressed(c_key_f1) && !game->chatting)
 			{
 				send_simple_packet(e_packet_cheat_last_level, ENET_PACKET_FLAG_RELIABLE);
 			}

--- a/src/linux_platform_client.cpp
+++ b/src/linux_platform_client.cpp
@@ -1,8 +1,7 @@
 #define m_client 1
 
-#include<GL/gl.h>
-#include<GL/glx.h>
-#include<GL/glext.h>
+#include "external/glcorearb.h"
+#include <GL/glx.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
@@ -190,24 +189,37 @@ func b8 handle_input_events(void)
 			xkey = &ev.xkey;
 			s_char_event char_event = zero;
 			KeySym sym = XLookupKeysym(xkey, 0);
-			switch(sym) {
-			case XK_KP_Add: sym = c_key_add; break;
-			case XK_KP_Subtract: sym = c_key_subtract; break;
-			case XK_w: sym = c_key_w; break;
-			case XK_a: sym = c_key_a; break;
-			case XK_s: sym = c_key_s; break;
-			case XK_d: sym = c_key_d; break;
-			case XK_Home: sym = c_key_home; break;
-			case XK_Left: sym = c_key_left; break;
-			case XK_Up: sym = c_key_up; break;
-			case XK_Right: sym = c_key_right; break;
-			case XK_Down: sym = c_key_down; break;
-			case XK_End: sym = c_key_end; break;
-			case XK_Delete: sym = c_key_delete; break;
-			case XK_Return: sym = c_key_enter; break;
-			case XK_Tab: sym = c_key_tab; break;
-			case XK_BackSpace: sym = c_key_backspace; break;
-			case XK_Escape: sym = c_key_escape; running = 0; break;
+			if (sym >= XK_a && sym <= XK_z)
+			{
+				sym = c_key_a + (sym - XK_a);
+			}
+			else if (sym >= XK_F1 && sym <= XK_F12)
+			{
+				sym = c_key_f1 + (sym - XK_F1);
+			}
+			else
+			{
+				switch(sym)
+				{
+				case XK_KP_Add: sym = c_key_add; break;
+				case XK_KP_Subtract: sym = c_key_subtract; break;
+				case XK_Home: sym = c_key_home; break;
+				case XK_Left: sym = c_key_left; break;
+				case XK_Up: sym = c_key_up; break;
+				case XK_Right: sym = c_key_right; break;
+				case XK_Down: sym = c_key_down; break;
+				case XK_End: sym = c_key_end; break;
+				case XK_Delete: sym = c_key_delete; break;
+				case XK_Return: sym = c_key_enter; break;
+				case XK_Tab: sym = c_key_tab; break;
+				case XK_BackSpace: sym = c_key_backspace; break;
+				case XK_Escape: sym = c_key_escape; break;
+				}
+			}
+			// quit with alt+f4 or with ctrl+q
+			if ((sym == c_key_f4 && (xkey->state & Mod1Mask)) || (sym == c_key_q && (xkey->state & ControlMask)))
+			{
+				running = 0;
 			}
 			b8 is_down = ev.type == KeyPress;
 			if (sym < c_max_keys) {
@@ -317,9 +329,10 @@ int main(void)
 	s_game_network game_network = zero;
 	s_platform_network platform_network = zero;
 	s_platform_data platform_data = zero;
-	game_network.read_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1*c_mb));
-	game_network.write_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1*c_mb));
-	platform_data.frame_arena = make_lin_arena_from_memory(5 * c_mb, la_get(&all, 5*c_mb));
+	game_network.read_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1 * c_mb));
+	game_network.write_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1 * c_mb));
+	s_lin_arena frame_arena = make_lin_arena_from_memory(5 * c_mb, la_get(&all, 5 * c_mb));
+	platform_data.frame_arena = &frame_arena;
 	glXSwapIntervalEXTProc = (PFNGLXSWAPINTERVALEXTPROC)glXGetProcAddress((const GLubyte*)"glXSwapIntervalEXT");
 
 	s_platform_funcs platform_funcs = zero;

--- a/src/linux_platform_server.cpp
+++ b/src/linux_platform_server.cpp
@@ -57,9 +57,10 @@ int main(void)
 	void *game_memory = la_get(&all, 1 * c_mb);
 	s_game_network game_network = zero;
 	s_platform_data platform_data = zero;
-	game_network.read_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1*c_mb));
-	game_network.write_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1*c_mb));
-	platform_data.frame_arena = make_lin_arena_from_memory(5 * c_mb, la_get(&all, 5*c_mb));
+	game_network.read_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1 * c_mb));
+	game_network.write_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1 * c_mb));
+	s_lin_arena frame_arena = make_lin_arena_from_memory(5 * c_mb, la_get(&all, 5 * c_mb));
+	platform_data.frame_arena = &frame_arena;
 
 	f64 time_passed = 0;
 	b8 need_so_reload = true;

--- a/src/platform_shared_client.h
+++ b/src/platform_shared_client.h
@@ -231,7 +231,7 @@ struct s_platform_data
 	f64 time_passed;
 	s_input* input;
 	s_sarray<s_char_event, 1024>* char_event_arr;
-	s_lin_arena frame_arena;
+	s_lin_arena* frame_arena;
 };
 
 struct s_platform_funcs

--- a/src/platform_shared_server.h
+++ b/src/platform_shared_server.h
@@ -11,7 +11,7 @@ struct s_platform_data
 {
 	b8 recompiled;
 	f64 time_passed;
-	s_lin_arena frame_arena;
+	s_lin_arena* frame_arena;
 };
 
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -48,7 +48,7 @@ m_update_game(update_game)
 {
 	static_assert(c_game_memory >= sizeof(s_game));
 
-	frame_arena = &platform_data.frame_arena;
+	frame_arena = platform_data.frame_arena;
 	g_network = game_network;
 	game = (s_game*)game_memory;
 	if(disgusting_recompile_hack) { return ; }

--- a/src/win32_platform_client.cpp
+++ b/src/win32_platform_client.cpp
@@ -70,6 +70,7 @@ int main(int argc, char** argv)
 	s_game_network game_network = zero;
 	s_platform_network platform_network = zero;
 	s_platform_data platform_data = zero;
+	s_lin_arena frame_arena = zero;
 
 	{
 		s_lin_arena all = zero;
@@ -81,7 +82,8 @@ int main(int argc, char** argv)
 		game_memory = la_get(&all, c_game_memory);
 		game_network.read_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1 * c_mb));
 		game_network.write_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1 * c_mb));
-		platform_data.frame_arena = make_lin_arena_from_memory(5 * c_mb, la_get(&all, 5 * c_mb));
+		frame_arena = make_lin_arena_from_memory(5 * c_mb, la_get(&all, 5 * c_mb));
+		platform_data.frame_arena = &frame_arena;
 
 	}
 

--- a/src/win32_platform_server.cpp
+++ b/src/win32_platform_server.cpp
@@ -58,6 +58,7 @@ int main(int argc, char** argv)
 	void* game_memory = null;
 	HMODULE dll = null;
 	s_platform_data platform_data = zero;
+	s_lin_arena frame_arena = zero;
 
 	{
 		s_lin_arena all = zero;
@@ -69,7 +70,8 @@ int main(int argc, char** argv)
 		game_memory = la_get(&all, c_game_memory);
 		game_network.read_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1 * c_mb));
 		game_network.write_arena = make_lin_arena_from_memory(1 * c_mb, la_get(&all, 1 * c_mb));
-		platform_data.frame_arena = make_lin_arena_from_memory(5 * c_mb, la_get(&all, 5 * c_mb));
+		frame_arena = make_lin_arena_from_memory(5 * c_mb, la_get(&all, 5 * c_mb));
+		platform_data.frame_arena = &frame_arena;
 	}
 
 	f64 time_passed = 0;


### PR DESCRIPTION
- Don't trigger cheats to change level when chatting.
- Fix triggering of level change on linux when pressing k and m.  On X, the keycodes for k and m are just their ascii encoding, so 0x6B and 0x6D. In the game, these are the key codes for c_key_add and c_key_subtract. Made the keycode mapping from XK_foo to c_key_foo more complete to fix that.
- Make game quit on linux when pressing alt+f4 or ctrl+q.

Some fixed warnings:
- Put frame arena outside of platform data and only store a pointer to it instead.  This is to prevent a warning in update_game which used to store a global frame arena pointer pointing to the local variable &platform_data.frame_arena.  Storing global pointers to local variables is not a good thing.  Interestingly, only gcc caught this, but clang didn't.
- Add -Wno-class-memaccess to linux_build.sh to silence warning when memsetting a "non-trivial" class like the level array.
- Add -Wno-sign-compare to silence warnings when comparing int with unsigned int in.  These warnings used to come up in for loops when doing for (int i = 0; i < array_count(...); i++) since array_count is a size_t.  gcc always warns in that case, even when the array_count is a small integer.

Some build-related improvements:
- Include glcorearb.h on linux too, instead of gl.h and the full glext.h, since glcorearb.h has all we need and is about half the size of glext.h
- Remove x86intrin.h include.  clang doesn't need it and for gcc we can just define rdtsc ourselves.
- Fix debug build flag in linux_build.sh (i am bigritard)