### PR TITLE
hot shader reload on linux for multiple gl progs

### DIFF
--- a/linux_build.sh
+++ b/linux_build.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
 cc="clang++"
+warn="-Werror -Wall -Wno-char-subscripts -Wno-unused-function -Wno-switch -Wno-sign-compare"
 if [ $cc = "g++" ] ; then
 	diag="-fno-diagnostics-show-caret"
+	warn="$warn -Wno-write-strings -Wno-class-memaccess"
 else
 	diag="-fno-caret-diagnostics"
+	warn="$warn -Wno-writable-strings"
 fi
-warn="-Werror -Wall -Wno-char-subscripts -Wno-unused-function -Wno-switch -Wno-class-memaccess -Wno-sign-compare"
+
 serverdef="-Dm_server -Dm_app"
 clientdef="-Dm_client -Dm_app"
 opt_debug="-std=c++17 -Isrc/ -g -Dm_debug"

--- a/src/client.h
+++ b/src/client.h
@@ -1,4 +1,3 @@
-
 enum e_string_input_result
 {
 	e_string_input_result_none,
@@ -78,9 +77,9 @@ struct s_shader_paths
 	#ifdef m_debug
 	#ifdef _WIN32
 	FILETIME last_write_time;
-	#else // _WIN32
-	ARUSEUS_FIX_THIS last_write_time;
-	#endif
+	#else
+	time_t last_write_time;
+	#endif // _WIN32
 	#endif // m_debug
 	char* vertex_path;
 	char* fragment_path;

--- a/src/platform_shared_client.h
+++ b/src/platform_shared_client.h
@@ -55,6 +55,7 @@ X(PFNGLVERTEXATTRIBDIVISORPROC, glVertexAttribDivisorProc) \
 X(PFNGLDRAWARRAYSINSTANCEDPROC, glDrawArraysInstancedProc) \
 X(PFNGLDEBUGMESSAGECALLBACKPROC, glDebugMessageCallbackProc) \
 X(PFNGLBINDBUFFERBASEPROC, glBindBufferBaseProc) \
+X(PFNGLUNIFORM1FVPROC, glUniform1fvProc) \
 X(PFNGLUNIFORM2FVPROC, glUniform2fvProc) \
 X(PFNGLGETUNIFORMLOCATIONPROC, glGetUniformLocationProc) \
 X(PFNGLUSEPROGRAMPROC, glUseProgramProc) \
@@ -89,6 +90,7 @@ X(PFNGLXSWAPINTERVALEXTPROC, glXSwapIntervalEXTProc)
 #define glDrawArraysInstanced glDrawArraysInstancedProc
 #define glDebugMessageCallback glDebugMessageCallbackProc
 #define glBindBufferBase glBindBufferBaseProc
+#define glUniform1fv glUniform1fvProc
 #define glUniform2fv glUniform2fvProc
 #define glGetUniformLocation glGetUniformLocationProc
 #define glUseProgram glUseProgramProc


### PR DESCRIPTION
- make shader hot reload on linux work just like on win32.
- remove unused variables percent2 and last_write_time.
- silence the const char* warnings, because I don't care that much.