### PR TITLE
Use c_game_memory on linux + small compile fixes

### DIFF
--- a/linux_build.sh
+++ b/linux_build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cc="clang++"
-warn="-Werror -Wall -Wno-char-subscripts -Wno-unused-function -Wno-switch -Wno-sign-compare"
+warn="-Werror -Wall -Wno-char-subscripts -Wno-unused-function -Wno-switch -Wno-sign-compare -Wno-unknown-pragmas"
 if [ $cc = "g++" ] ; then
 	diag="-fno-diagnostics-show-caret"
 	warn="$warn -Wno-write-strings -Wno-class-memaccess"

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -36,11 +36,13 @@ static constexpr int ENET_PACKET_FLAG_RELIABLE = 1;
 #define STBTT_assert assert
 #include "external/stb_truetype.h"
 
+#undef zero
 #pragma warning(push, 0)
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_assert assert
 #include "external/stb_image.h"
 #pragma warning(pop)
+#define zero {}
 
 #include "epic_math.h"
 #include "config.h"

--- a/src/epic_math.h
+++ b/src/epic_math.h
@@ -245,7 +245,7 @@ func float range_lerp(float input_val, float input_start, float input_end, float
 	return output_start + ((output_end - output_start) / (input_end - input_start)) * (input_val - input_start);
 }
 
-s_v3 hsv_to_rgb(s_v3 colour)
+func s_v3 hsv_to_rgb(s_v3 colour)
 {
 	s_v3 rgb;
 

--- a/src/linux_platform_client.cpp
+++ b/src/linux_platform_client.cpp
@@ -325,7 +325,7 @@ int main(void)
 	all.capacity = 20 * c_mb;
 	all.memory = calloc(all.capacity, 1);
 
-	void *game_memory = la_get(&all, 1 * c_mb);
+	void *game_memory = la_get(&all, c_game_memory);
 	s_game_network game_network = zero;
 	s_platform_network platform_network = zero;
 	s_platform_data platform_data = zero;


### PR DESCRIPTION
- Add -Wno-unknown-pragmas since gcc/clang don't have #pragma warning 
- #undef zero around stb_image.h since stb uses a variable called zero.
- add `func to hsv_to_rgb
- Use c_game_memory (3mb) in linux client instead of hardcoded 1mb. Seems to fix the bug where already connected players didn't show.