### PR TITLE
fix key repeats on linux

### DIFF
--- a/src/linux_platform_client.cpp
+++ b/src/linux_platform_client.cpp
@@ -176,15 +176,24 @@ func b8 handle_input_events(void)
 	b8 running = true;
 	int newwidth = 0;
 	int newheight = 0;
-	XEvent ev;
+	XEvent ev, ev2;
 	char text[32];
 	XKeyEvent *xkey;
 	while(XCheckWindowEvent(g_window.display, g_window.window, EventMask, &ev)) {
 		switch(ev.type) {
 		case Expose:
 			break;
-		case KeyPress:
 		case KeyRelease:
+			// check for fake key repeat events and ignore them.
+			if(ev.type == KeyRelease && XEventsQueued(g_window.display, QueuedAfterReading)) {
+				XPeekEvent(g_window.display, &ev2);
+				if(ev2.type == KeyPress && ev2.xkey.time == ev.xkey.time && ev2.xkey.keycode == ev.xkey.keycode){
+					XNextEvent(g_window.display, &ev2);
+					continue;
+				}
+			}
+			// fallthrough
+		case KeyPress:
 			{
 			xkey = &ev.xkey;
 			s_char_event char_event = zero;


### PR DESCRIPTION
detect and ignore key repeat events since they would interfere with holding up to jump higher.